### PR TITLE
Add TimeService.apk

### DIFF
--- a/device-proprietary-files.txt
+++ b/device-proprietary-files.txt
@@ -119,6 +119,7 @@ bin/ssr_setup
 bin/time_daemon
 -vendor/lib/libtime_genoff.so
 -vendor/lib64/libtime_genoff.so
+-app/TimeService/TimeService.apk
 
 # USB
 bin/port-bridge


### PR DESCRIPTION
Without this apk, device time/date will reset to 1970 when you reboot.  You can test this by turning on "airplane mode" and doing a reboot.